### PR TITLE
Support Java 8 (class version 52)

### DIFF
--- a/kmp-zip-cli/build.gradle.kts
+++ b/kmp-zip-cli/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 }
 
 kotlin {
+    jvmToolchain(8)
     jvm {
         mainRun {
             mainClass.set("no.synth.kmpzip.cli.MainKt")

--- a/kmp-zip-kotlinx/build.gradle.kts
+++ b/kmp-zip-kotlinx/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 }
 
 kotlin {
+    jvmToolchain(8)
     jvm()
     iosArm64()
     iosSimulatorArm64()

--- a/kmp-zip-okio/build.gradle.kts
+++ b/kmp-zip-okio/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 }
 
 kotlin {
+    jvmToolchain(8)
     jvm()
     iosArm64()
     iosSimulatorArm64()

--- a/kmp-zip/build.gradle.kts
+++ b/kmp-zip/build.gradle.kts
@@ -109,6 +109,7 @@ val generateWasmJsTestData = tasks.register("generateWasmJsTestData") {
 }
 
 kotlin {
+    jvmToolchain(8)
     jvm()
     iosArm64()
     iosSimulatorArm64()

--- a/kmp-zip/src/jvmTest/kotlin/no/synth/kmpzip/zip/TestData.jvm.kt
+++ b/kmp-zip/src/jvmTest/kotlin/no/synth/kmpzip/zip/TestData.jvm.kt
@@ -2,7 +2,7 @@ package no.synth.kmpzip.zip
 
 actual object TestData {
     actual fun loadResource(name: String): ByteArray {
-        return TestData::class.java.getResourceAsStream("/testdata/$name")?.readAllBytes()
+        return TestData::class.java.getResourceAsStream("/testdata/$name")?.readBytes()
             ?: error("Resource not found: testdata/$name")
     }
 

--- a/kmp-zip/src/jvmTest/kotlin/no/synth/kmpzip/zip/Zip4jInvestigationTest.kt
+++ b/kmp-zip/src/jvmTest/kotlin/no/synth/kmpzip/zip/Zip4jInvestigationTest.kt
@@ -359,7 +359,7 @@ class Zip4jInvestigationTest {
         val entry = zip4jInput.nextEntry
         assertNotNull(entry)
         assertEquals("kmpzip.txt", entry.fileName)
-        assertEquals(content, zip4jInput.readAllBytes().decodeToString())
+        assertEquals(content, zip4jInput.readBytes().decodeToString())
         assertNull(zip4jInput.nextEntry)
         zip4jInput.close()
     }
@@ -387,7 +387,7 @@ class Zip4jInvestigationTest {
             val entry = zip4jInput.nextEntry
             assertNotNull(entry, "Expected entry: $expectedName")
             assertEquals(expectedName, entry.fileName)
-            assertEquals(expectedContent, zip4jInput.readAllBytes().decodeToString())
+            assertEquals(expectedContent, zip4jInput.readBytes().decodeToString())
         }
         assertNull(zip4jInput.nextEntry)
         zip4jInput.close()
@@ -410,7 +410,7 @@ class Zip4jInvestigationTest {
         val entry = zip4jInput.nextEntry
         assertNotNull(entry)
         assertEquals("legacy.txt", entry.fileName)
-        assertEquals(content, zip4jInput.readAllBytes().decodeToString())
+        assertEquals(content, zip4jInput.readBytes().decodeToString())
         assertNull(zip4jInput.nextEntry)
         zip4jInput.close()
     }
@@ -436,7 +436,7 @@ class Zip4jInvestigationTest {
         val readEntry = zip4jInput.nextEntry
         assertNotNull(readEntry)
         assertEquals("stored.txt", readEntry.fileName)
-        assertEquals(content, zip4jInput.readAllBytes().decodeToString())
+        assertEquals(content, zip4jInput.readBytes().decodeToString())
         assertNull(zip4jInput.nextEntry)
         zip4jInput.close()
     }


### PR DESCRIPTION
This pull request pins the Java toolchain version to level 8, so the project will be compiled with class verison 52. This is important for compatibility with other projects that cannot upgrade for some reason or another, and it turns out the transition is absolutely painless in this case.

Java toolchain version was previously unpinned and project was compiled at version level Java 21 (class version 65).