### PR TITLE
Drop MacOS x64 Support (Deprecated in Kotlin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - os: macos-latest
             tasks: ":kmp-zip:jvmTest :kmp-zip:iosSimulatorArm64Test :kmp-zip:macosArm64Test :kmp-zip:wasmJsNodeTest :samples:wasmjs-demo:wasmJsNodeTest :kmp-zip-okio:check :kmp-zip-kotlinx:check :kmp-zip-cli:jvmTest :kmp-zip-cli:macosArm64Test"
-            cli-link-tasks: ":kmp-zip-cli:linkReleaseExecutableMacosArm64 :kmp-zip-cli:linkReleaseExecutableMacosX64"
+            cli-link-tasks: ":kmp-zip-cli:linkReleaseExecutableMacosArm64"
             primary: true
           - os: ubuntu-latest
             tasks: ":kmp-zip:jvmTest :kmp-zip:linuxX64Test :kmp-zip-okio:linuxX64Test :kmp-zip-kotlinx:linuxX64Test :kmp-zip-cli:jvmTest :kmp-zip-cli:linuxX64Test"
@@ -59,13 +59,6 @@ jobs:
         with:
           name: kmpzip-macos-arm64
           path: kmp-zip-cli/build/bin/macosArm64/releaseExecutable/kmpzip-macos-arm64
-          archive: false
-          if-no-files-found: error
-      - uses: actions/upload-artifact@v7
-        if: matrix.os == 'macos-latest'
-        with:
-          name: kmpzip-macos-x64
-          path: kmp-zip-cli/build/bin/macosX64/releaseExecutable/kmpzip-macos-x64
           archive: false
           if-no-files-found: error
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,6 @@ jobs:
           generate_release_notes: true
           files: |
             kmp-zip-cli/build/bin/macosArm64/releaseExecutable/kmpzip-macos-arm64
-            kmp-zip-cli/build/bin/macosX64/releaseExecutable/kmpzip-macos-x64
             kmp-zip-cli/build/bin/linuxX64/releaseExecutable/kmpzip-linux-x64
             kmp-zip-cli/build/bin/linuxArm64/releaseExecutable/kmpzip-linux-arm64
             kmp-zip-cli/build/bin/mingwX64/releaseExecutable/kmpzip-windows-x64.exe

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All ZIP, GZIP, and crypto logic is implemented in common Kotlin. Platform-specif
 
 - **JVM** (also consumable from Android projects)
 - **iosArm64**, **iosSimulatorArm64**
-- **macosArm64**, **macosX64**
+- **macosArm64**
 - **linuxX64**, **linuxArm64**
 - **mingwX64**
 - **wasmJs** (browser, Node 20+) — see [wasmJs notes](#wasmjs-notes) below
@@ -507,7 +507,7 @@ Prebuilt binaries for macOS, Linux, and Windows are also attached to each [GitHu
 Alternatively, build a native binary from source:
 
 ```sh
-./gradlew :kmp-zip-cli:linkReleaseExecutableMacosArm64   # or MacosX64, LinuxX64, LinuxArm64, MingwX64
+./gradlew :kmp-zip-cli:linkReleaseExecutableMacosArm64   # or LinuxX64, LinuxArm64, MingwX64
 kmp-zip-cli/build/bin/macosArm64/releaseExecutable/kmpzip-macos-arm64 <command> [options] [args]
 ```
 

--- a/kmp-zip-cli/build.gradle.kts
+++ b/kmp-zip-cli/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
         }
     }
     macosArm64 { binaries { executable { entryPoint = "no.synth.kmpzip.cli.main"; baseName = "kmpzip-macos-arm64" } } }
-    macosX64 { binaries { executable { entryPoint = "no.synth.kmpzip.cli.main"; baseName = "kmpzip-macos-x64" } } }
     linuxX64 { binaries { executable { entryPoint = "no.synth.kmpzip.cli.main"; baseName = "kmpzip-linux-x64" } } }
     linuxArm64 { binaries { executable { entryPoint = "no.synth.kmpzip.cli.main"; baseName = "kmpzip-linux-arm64" } } }
     mingwX64 { binaries { executable { entryPoint = "no.synth.kmpzip.cli.main"; baseName = "kmpzip-windows-x64" } } }

--- a/kmp-zip-kotlinx/build.gradle.kts
+++ b/kmp-zip-kotlinx/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     macosArm64()
-    macosX64()
     linuxX64()
     linuxArm64()
     mingwX64()

--- a/kmp-zip-okio/build.gradle.kts
+++ b/kmp-zip-okio/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     macosArm64()
-    macosX64()
     linuxX64()
     linuxArm64()
     mingwX64()

--- a/kmp-zip/build.gradle.kts
+++ b/kmp-zip/build.gradle.kts
@@ -113,7 +113,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
     macosArm64()
-    macosX64()
     linuxX64()
     linuxArm64()
     mingwX64 {


### PR DESCRIPTION
Not necessary to merge, yet. This removes the [now-deprecated](https://youtrack.jetbrains.com/issue/KT-78660) macosX64 target.